### PR TITLE
Remove typo and try to run tests

### DIFF
--- a/app/src/test/java/a1template/CaesarCipherTests.java
+++ b/app/src/test/java/a1template/CaesarCipherTests.java
@@ -29,7 +29,6 @@ package a1template;
          assertEquals('w',classUnderTest.get(9));
          assertEquals('a',classUnderTest.get(13));
     }
-}
 
     
      @Test


### PR DESCRIPTION
Hi @BebeCosgrove, I noticed your tests weren't running. It seems like you had a typo that was preventing it from compiling. Here is a potential fix, let's see if the tests run!